### PR TITLE
feat: Update quick links to point to official government websites

### DIFF
--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -301,28 +301,23 @@ export default function CivicPlatform() {
               <h4 className="mb-2 font-semibold text-slate-900">Quick Links</h4>
               <ul className="space-y-1 text-sm text-slate-600">
                 <li>
-                  <a href="#" className="hover:text-blue-600">
+                  <a href="https://www.parliament.lk/" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600">
                     Parliament of Sri Lanka
                   </a>
                 </li>
                 <li>
-                  <a href="#" className="hover:text-blue-600">
+                  <a href="https://www.presidentsoffice.gov.lk/" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600">
                     Presidential Secretariat
                   </a>
                 </li>
                 <li>
-                  <a href="#" className="hover:text-blue-600">
+                  <a href="https://www.gov.lk/webdirectory/provincialcouncils" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600">
                     Provincial Councils
                   </a>
                 </li>
                 <li>
-                  <a href="#" className="hover:text-blue-600">
+                  <a href="https://mpclg.gov.lk/web/index.php?option=com_content&view=article&id=69&Itemid=188&lang=en" target="_blank" rel="noopener noreferrer" className="hover:text-blue-600">
                     Local Government
-                  </a>
-                </li>
-                <li>
-                  <a href="/signup" className="hover:text-blue-600">
-                    sign up
                   </a>
                 </li>
               </ul>


### PR DESCRIPTION
This pull request updates the "Quick Links" section in the `CivicPlatform` component to provide direct external links to official Sri Lankan government websites, and removes the internal "sign up" link.

Improvements to Quick Links:

* Updated each "Quick Links" item to use the actual URL for the Parliament of Sri Lanka, Presidential Secretariat, Provincial Councils, and Local Government, opening them in a new tab with appropriate security attributes (`target="_blank"` and `rel="noopener noreferrer"`).

Other changes:

* Removed the internal "sign up" link from the list to focus the section solely on government resources.